### PR TITLE
add readiness and liveness probes and resource bounds to components and Jenkins templates

### DIFF
--- a/templates/helm/jenkins/templates/deployment.yaml
+++ b/templates/helm/jenkins/templates/deployment.yaml
@@ -18,12 +18,12 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
-        - containerPort: {{ .Values.service.port }}
+        - containerPort: {{ .Values.service.targetPort }}
         - containerPort: 50000
         livenessProbe:
           httpGet:
             path: /login
-            port: {{ .Values.service.port }}
+            port: {{ .Values.service.targetPort }}
             scheme: HTTP
           initialDelaySeconds: 660
           periodSeconds: 4
@@ -33,7 +33,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /login
-            port: {{ .Values.service.port }}
+            port: {{ .Values.service.targetPort }}
             scheme: HTTP
           periodSeconds: 11
           successThreshold: 2
@@ -60,7 +60,7 @@ spec:
         lifecycle:
           postStart:
             exec:
-              command: ["/bin/sh", "-c", "for i in $(seq 1 20); do if [ -f /var/lib/jenkins/jobs/{{ .Values.infra.jobName }}/nextBuildNumber ]; then NEXT_BUILD_NUMBER=$(cat /var/lib/jenkins/jobs/{{ .Values.infra.jobName }}/nextBuildNumber); else NEXT_BUILD_NUMBER=1; fi; if [ $NEXT_BUILD_NUMBER -ge 2 ]; then break; fi; if curl -f localhost:{{ .Values.service.port }}/login &> /dev/null ; then curl -X POST localhost:{{ .Values.service.port }}/job/{{ .Values.infra.jobName }}/build --user admin:${JENKINS_PASSWORD}; break; else sleep 10; fi; done"]
+              command: ["/bin/sh", "-c", "for i in $(seq 1 20); do if [ -f /var/lib/jenkins/jobs/{{ .Values.infra.jobName }}/nextBuildNumber ]; then NEXT_BUILD_NUMBER=$(cat /var/lib/jenkins/jobs/{{ .Values.infra.jobName }}/nextBuildNumber); else NEXT_BUILD_NUMBER=1; fi; if [ $NEXT_BUILD_NUMBER -ge 2 ]; then break; fi; if curl -f localhost:{{ .Values.service.targetPort }}/login &> /dev/null ; then curl -X POST localhost:{{ .Values.service.targetPort }}/job/{{ .Values.infra.jobName }}/build --user admin:${JENKINS_PASSWORD}; break; else sleep 10; fi; done"]
       initContainers:
       - name: setup-permissions
         image: alpine:latest

--- a/templates/helm/jenkins/templates/deployment.yaml
+++ b/templates/helm/jenkins/templates/deployment.yaml
@@ -18,16 +18,34 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
-        - containerPort: 8080
+        - containerPort: {{ .Values.service.port }}
         - containerPort: 50000
+        livenessProbe:
+          httpGet:
+            path: /login
+            port: {{ .Values.service.port }}
+            scheme: HTTP
+          initialDelaySeconds: 660
+          periodSeconds: 4
+          successThreshold: 1
+          failureThreshold: 4
+          timeoutSeconds: 12
         readinessProbe:
           httpGet:
             path: /login
-            port: 8080
-          periodSeconds: 10
-          timeoutSeconds: 5
+            port: {{ .Values.service.port }}
+            scheme: HTTP
+          periodSeconds: 11
           successThreshold: 2
           failureThreshold: 5
+          timeoutSeconds: 12
+        resources:
+          limits:
+            cpu: 300m
+            memory: 800Mi
+          requests:
+            cpu: 300m
+            memory: 800Mi
         env:
         - name: JAVA_OPTS
           value: "-Djenkins.install.runSetupWizard=false"
@@ -42,7 +60,7 @@ spec:
         lifecycle:
           postStart:
             exec:
-              command: ["/bin/sh", "-c", "for i in $(seq 1 20); do if [ -f /var/lib/jenkins/jobs/{{ .Values.infra.jobName }}/nextBuildNumber ]; then NEXT_BUILD_NUMBER=$(cat /var/lib/jenkins/jobs/{{ .Values.infra.jobName }}/nextBuildNumber); else NEXT_BUILD_NUMBER=1; fi; if [ $NEXT_BUILD_NUMBER -ge 2 ]; then break; fi; if curl -f localhost:8080/login &> /dev/null ; then curl -X POST localhost:8080/job/{{ .Values.infra.jobName }}/build --user admin:${JENKINS_PASSWORD}; break; else sleep 10; fi; done"]
+              command: ["/bin/sh", "-c", "for i in $(seq 1 20); do if [ -f /var/lib/jenkins/jobs/{{ .Values.infra.jobName }}/nextBuildNumber ]; then NEXT_BUILD_NUMBER=$(cat /var/lib/jenkins/jobs/{{ .Values.infra.jobName }}/nextBuildNumber); else NEXT_BUILD_NUMBER=1; fi; if [ $NEXT_BUILD_NUMBER -ge 2 ]; then break; fi; if curl -f localhost:{{ .Values.service.port }}/login &> /dev/null ; then curl -X POST localhost:{{ .Values.service.port }}/job/{{ .Values.infra.jobName }}/build --user admin:${JENKINS_PASSWORD}; break; else sleep 10; fi; done"]
       initContainers:
       - name: setup-permissions
         image: alpine:latest

--- a/templates/helm/nexus/templates/deployment.yaml
+++ b/templates/helm/nexus/templates/deployment.yaml
@@ -63,7 +63,6 @@ spec:
           periodSeconds: 4
           successThreshold: 1
           timeoutSeconds: 5
-        name: nexus
         readinessProbe:
           failureThreshold: 2
           httpGet:

--- a/templates/helm/nexus/templates/deployment.yaml
+++ b/templates/helm/nexus/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
                 while true; do
                   /mnt/initialize_nexus_repos.sh
                     --connection_check
-                    --url http://127.0.0.1:8081 && break;
+                    --url http://127.0.0.1:{{ .Values.service.port }} && break;
                   sleep 10;
                 done &&
                 ADMIN_PASSWORD=$(/usr/bin/cat /nexus-data/admin.password) &&
@@ -47,12 +47,40 @@ spec:
                   --user admin
                   --password $ADMIN_PASSWORD
                   --new_admin_password {{ .Values.newAdminPassword }}
-                  --url http://127.0.0.1:8081 &&
+                  --url http://127.0.0.1:{{ .Values.service.port }} &&
                 /mnt/initialize_nexus_repos.sh
                   --user admin
                   --password {{ .Values.newAdminPassword }}
-                  --url http://127.0.0.1:8081
+                  --url http://127.0.0.1:{{ .Values.service.port }}
                 ;} &> /tmp/init.log"]
+        livenessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /
+            port: {{ .Values.service.port }}
+            scheme: HTTP
+          initialDelaySeconds: 300
+          periodSeconds: 4
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: nexus
+        readinessProbe:
+          failureThreshold: 2
+          httpGet:
+            path: /
+            port: {{ .Values.service.port }}
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 2
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 200m
+            memory: 1900Mi
+          requests:
+            cpu: 200m
+            memory: 1900Mi
       initContainers:
       - name: prepare-data-volume
         image: alpine:latest

--- a/templates/helm/nexus/templates/deployment.yaml
+++ b/templates/helm/nexus/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
                 while true; do
                   /mnt/initialize_nexus_repos.sh
                     --connection_check
-                    --url http://127.0.0.1:{{ .Values.service.port }} && break;
+                    --url http://127.0.0.1:{{ .Values.service.targetPort }} && break;
                   sleep 10;
                 done &&
                 ADMIN_PASSWORD=$(/usr/bin/cat /nexus-data/admin.password) &&
@@ -47,17 +47,17 @@ spec:
                   --user admin
                   --password $ADMIN_PASSWORD
                   --new_admin_password {{ .Values.newAdminPassword }}
-                  --url http://127.0.0.1:{{ .Values.service.port }} &&
+                  --url http://127.0.0.1:{{ .Values.service.targetPort }} &&
                 /mnt/initialize_nexus_repos.sh
                   --user admin
                   --password {{ .Values.newAdminPassword }}
-                  --url http://127.0.0.1:{{ .Values.service.port }}
+                  --url http://127.0.0.1:{{ .Values.service.targetPort }}
                 ;} &> /tmp/init.log"]
         livenessProbe:
           failureThreshold: 4
           httpGet:
             path: /
-            port: {{ .Values.service.port }}
+            port: {{ .Values.service.targetPort }}
             scheme: HTTP
           initialDelaySeconds: 300
           periodSeconds: 4
@@ -67,7 +67,7 @@ spec:
           failureThreshold: 2
           httpGet:
             path: /
-            port: {{ .Values.service.port }}
+            port: {{ .Values.service.targetPort }}
             scheme: HTTP
           initialDelaySeconds: 10
           periodSeconds: 10

--- a/templates/helm/postgresql/templates/deployment.yaml
+++ b/templates/helm/postgresql/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               cpu: 100m
               memory: 200Mi
           ports:
-            - containerPort: {{ .Values.service.port }}
+            - containerPort: {{ .Values.service.targetPort }}
           envFrom:
             - configMapRef:
                 name: {{ include "postgresql.fullname" . }}-config

--- a/templates/helm/postgresql/templates/deployment.yaml
+++ b/templates/helm/postgresql/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
           livenessProbe:
             failureThreshold: 1
             exec:
-              command: ["psql", "-w", "-d", "sonar", "-U", "sonar", "-c", "SELECT 1"
+              command: ["psql", "-w", "-d", "sonar", "-U", "sonar", "-c", "SELECT 1"]
             initialDelaySeconds: 50
             periodSeconds: 2
             successThreshold: 1
@@ -25,7 +25,7 @@ spec:
           readinessProbe:
             failureThreshold: 4
             exec:
-              command: ["psql", "-w", "-d", "sonar", "-U", "sonar", "-c", "SELECT 1"
+              command: ["psql", "-w", "-d", "sonar", "-U", "sonar", "-c", "SELECT 1"]
             initialDelaySeconds: 15
             periodSeconds: 1
             successThreshold: 1

--- a/templates/helm/postgresql/templates/deployment.yaml
+++ b/templates/helm/postgresql/templates/deployment.yaml
@@ -14,8 +14,31 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          livenessProbe:
+            failureThreshold: 1
+            exec:
+              command: ["psql", "-w", "-d", "sonar", "-U", "sonar", "-c", "SELECT 1"
+            initialDelaySeconds: 50
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 3
+          readinessProbe:
+            failureThreshold: 4
+            exec:
+              command: ["psql", "-w", "-d", "sonar", "-U", "sonar", "-c", "SELECT 1"
+            initialDelaySeconds: 15
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources:
+            limits:
+              cpu: 100m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
           ports:
-            - containerPort: 5432
+            - containerPort: {{ .Values.service.port }}
           envFrom:
             - configMapRef:
                 name: {{ include "postgresql.fullname" . }}-config

--- a/templates/helm/postgresql/values.yaml
+++ b/templates/helm/postgresql/values.yaml
@@ -25,6 +25,7 @@ fullnameOverride: ""
 service:
   type: ClusterIP
   port: 5432
+  targetPort: 5432
 
 ingress:
   enabled: false

--- a/templates/helm/sonarqube/templates/deployment.yaml
+++ b/templates/helm/sonarqube/templates/deployment.yaml
@@ -26,7 +26,34 @@ spec:
       - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: {{ .Chart.Name }}
-        resources: {}
+        livenessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /
+            port: {{ .Values.service.port }}
+            scheme: HTTP
+          initialDelaySeconds: 300
+          periodSeconds: 4
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: sonarqube
+        readinessProbe:
+          failureThreshold: 2
+          httpGet:
+            path: /
+            port: {{ .Values.service.port }}
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 2
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 150m
+            memory: 1900Mi
+          requests:
+            cpu: 150m
+            memory: 1900Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         envFrom:

--- a/templates/helm/sonarqube/templates/deployment.yaml
+++ b/templates/helm/sonarqube/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           failureThreshold: 4
           httpGet:
             path: /
-            port: {{ .Values.service.port }}
+            port: {{ .Values.service.targetPort }}
             scheme: HTTP
           initialDelaySeconds: 300
           periodSeconds: 4
@@ -40,7 +40,7 @@ spec:
           failureThreshold: 2
           httpGet:
             path: /
-            port: {{ .Values.service.port }}
+            port: {{ .Values.service.targetPort }}
             scheme: HTTP
           initialDelaySeconds: 10
           periodSeconds: 10

--- a/templates/helm/sonarqube/templates/deployment.yaml
+++ b/templates/helm/sonarqube/templates/deployment.yaml
@@ -36,7 +36,6 @@ spec:
           periodSeconds: 4
           successThreshold: 1
           timeoutSeconds: 5
-        name: sonarqube
         readinessProbe:
           failureThreshold: 2
           httpGet:


### PR DESCRIPTION
Tested( haphazardly) to work in our Azure dev account.
Setting of resource bounds helps Kubernetes to assign highest QoS class to the components( incl. Jenkins) which should make those pods more resilient inside the cluster, esp. regarding eviction policies. 
Minor cleanups of deployment ports in helm defs included.
Sadly, I didn't know startupProbe so that is not implemented. The readinessProbes are supposed to cover that to some extent, I hope.