### PR TITLE
fix jenkins-persistent.yaml to update kubectl in the infra pipepeline

### DIFF
--- a/templates/jenkins-persistent.yaml
+++ b/templates/jenkins-persistent.yaml
@@ -199,6 +199,14 @@ data:
     def nexus_admin_password = &apos;admin123&apos;
     
     node {
+  stage(&apos;Update kubectl tool&apos;) {
+        sh &quot;kubectl version&quot;
+        sh &quot;curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl&quot;
+        sh &quot;chmod +x kubectl&quot;
+        sh &quot;mv kubectl `which kubectl`&quot;
+        sh &quot;kubectl version&quot;
+      }
+      
       stage(&apos;Cleanup&apos;) {
         delete_namespace(components_namespace)
         delete_namespace(app_dev_namespace)


### PR DESCRIPTION
should update kubectl binary on start of infra pipeline.
hotfix for the alfa release needed for components and load to be deployed to AKS v.>1.13.05 in our Jenkins pipelines.